### PR TITLE
Normalize inspection template codes

### DIFF
--- a/lib/core/templates.dart
+++ b/lib/core/templates.dart
@@ -6,7 +6,7 @@ class Question {
 }
 
 class TemplateDef {
-  final String code; // 'pequeno', 'grande', ...
+  final String code; // 'comercio_pequeno', 'comercio_grande', ...
   final String name;
   final int passingScore; // puntaje mínimo para “aprobado”
   final List<Question> questions;
@@ -21,7 +21,7 @@ class TemplateDef {
 
 const templates = <TemplateDef>[
   TemplateDef(
-    code: 'pequeno',
+    code: 'comercio_pequeno',
     name: 'Comercio pequeño',
     passingScore: 70,
     questions: [
@@ -33,7 +33,7 @@ const templates = <TemplateDef>[
     ],
   ),
   TemplateDef(
-    code: 'grande',
+    code: 'comercio_grande',
     name: 'Comercio grande',
     passingScore: 80,
     questions: [
@@ -45,7 +45,7 @@ const templates = <TemplateDef>[
     ],
   ),
   TemplateDef(
-    code: 'estacion',
+    code: 'estacion_servicio',
     name: 'Estación de servicio',
     passingScore: 85,
     questions: [
@@ -70,7 +70,26 @@ const templates = <TemplateDef>[
   ),
 ];
 
+String normalizeTemplateCode(String? code) {
+  switch (code) {
+    case 'comercio_pequeno':
+    case 'pequeno':
+      return 'comercio_pequeno';
+    case 'comercio_grande':
+    case 'grande':
+      return 'comercio_grande';
+    case 'estacion_servicio':
+    case 'estacion':
+      return 'estacion_servicio';
+    case 'industria':
+      return 'industria';
+    default:
+      return templates.first.code;
+  }
+}
+
 TemplateDef templateByCode(String code) {
-  return templates.firstWhere((t) => t.code == code, orElse: () => templates.first);
+  final normalized = normalizeTemplateCode(code);
+  return templates.firstWhere((t) => t.code == normalized, orElse: () => templates.first);
 }
 

--- a/lib/features/inspections/evaluation_page.dart
+++ b/lib/features/inspections/evaluation_page.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import '../../core/templates.dart';
+
 /// Dropdown a prueba de crashes:
 class SafeDropdownFormField<T> extends StatelessWidget {
   final T? value;
@@ -82,8 +84,9 @@ class _EvaluationPageState extends State<EvaluationPage> {
   @override
   void initState() {
     super.initState();
-    final t = widget.initialData['tipo_inspeccion'] as String?;
-    _tipo = _tipos.contains(t) ? t : null;
+    final raw = widget.initialData['tipo_inspeccion'] as String?;
+    final normalized = normalizeTemplateCode(raw);
+    _tipo = _tipos.contains(normalized) ? normalized : null;
   }
 
   List<Map<String, dynamic>> _getQuestions(String tipo) {

--- a/lib/features/inspections/new_inspection_wizard.dart
+++ b/lib/features/inspections/new_inspection_wizard.dart
@@ -26,7 +26,7 @@ class _NewInspectionWizardState extends ConsumerState<NewInspectionWizard> {
   final _phoneCtrl = TextEditingController();
 
   // Paso B — Plantilla (NO nulo)
-  String _templateCode = 'pequeno';
+  String _templateCode = 'comercio_pequeno';
 
   // Paso C — Respuestas, notas y fotos
   // answer: 'yes' | 'no' | 'na'
@@ -47,8 +47,8 @@ class _NewInspectionWizardState extends ConsumerState<NewInspectionWizard> {
       _addrCtrl.text = (ex['direccion_rut'] ?? '') as String;
       _respCtrl.text = (ex['responsible'] ?? '') as String;
       _phoneCtrl.text = (ex['phone'] ?? '') as String;
-      final t = (ex['tipo_inspeccion'] ?? 'pequeno') as String;
-      if (t.isNotEmpty) _templateCode = t;
+      final t = normalizeTemplateCode(ex['tipo_inspeccion'] as String?);
+      _templateCode = t;
 
       final Map<String, dynamic>? ans =
           ex['answers'] == null ? null : Map<String, dynamic>.from(ex['answers'] as Map);


### PR DESCRIPTION
## Summary
- align template definitions with the "comercio_*" inspection type values
- add a normalization helper so legacy codes like `pequeno` keep working
- update the wizard and evaluation pages to rely on the normalized codes

## Testing
- `flutter analyze` *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68deb4d240d08330a889e9fa79e42469