### PR TITLE
Fix analyzer const list issues in dropdown widgets

### DIFF
--- a/lib/core/pdf_service.dart
+++ b/lib/core/pdf_service.dart
@@ -1,7 +1,6 @@
 import 'dart:typed_data';
 import 'package:pdf/pdf.dart';
 import 'package:pdf/widgets.dart' as pw;
-import 'package:printing/printing.dart';
 import 'package:http/http.dart' as http;
 
 class PdfService {
@@ -736,7 +735,7 @@ class _VisitaAnterior {
   final bool emergenciasUltimoAnio;
 
   factory _VisitaAnterior.fromMap(Map<String, dynamic> map) {
-    bool _toBool(dynamic value) {
+    bool toBool(dynamic value) {
       if (value is bool) return value;
       if (value is num) return value != 0;
       if (value is String) {
@@ -747,8 +746,8 @@ class _VisitaAnterior {
     }
 
     return _VisitaAnterior(
-      subsanadasObsPrevias: _toBool(map['subsanadas_obs_previas']),
-      emergenciasUltimoAnio: _toBool(map['emergencias_ultimo_anio']),
+      subsanadasObsPrevias: toBool(map['subsanadas_obs_previas']),
+      emergenciasUltimoAnio: toBool(map['emergencias_ultimo_anio']),
     );
   }
 }

--- a/lib/features/inspections/add_inspection_page.dart
+++ b/lib/features/inspections/add_inspection_page.dart
@@ -153,11 +153,11 @@ class _AddInspectionPageState extends ConsumerState<AddInspectionPage> {
             const SizedBox(height: 12),
             DropdownButtonFormField<String>(
               value: _tipoInspeccion,
-              items: const [
-                DropdownMenuItem(value: 'comercio_pequeno', child: Text('Comercio pequeño')),
-                DropdownMenuItem(value: 'comercio_grande', child: Text('Comercio grande')),
-                DropdownMenuItem(value: 'estacion_servicio', child: Text('Estación de servicio')),
-                DropdownMenuItem(value: 'industria', child: Text('Industria')),
+              items: [
+                const DropdownMenuItem(value: 'comercio_pequeno', child: Text('Comercio pequeño')),
+                const DropdownMenuItem(value: 'comercio_grande', child: Text('Comercio grande')),
+                const DropdownMenuItem(value: 'estacion_servicio', child: Text('Estación de servicio')),
+                const DropdownMenuItem(value: 'industria', child: Text('Industria')),
               ],
               onChanged: (v) => setState(() => _tipoInspeccion = v ?? 'comercio_pequeno'),
               decoration: const InputDecoration(labelText: 'Tipo de inspección'),

--- a/lib/features/inspections/modules_evaluation_page.dart
+++ b/lib/features/inspections/modules_evaluation_page.dart
@@ -114,10 +114,10 @@ class _ModulesEvaluationPageState extends ConsumerState<ModulesEvaluationPage> {
       final val = _answers[key] ?? 'no';
       return DropdownButtonFormField<String>(
         value: val,
-        items: const [
-          DropdownMenuItem(value: 'yes', child: Text('Sí / Cumple')),
-          DropdownMenuItem(value: 'no', child: Text('No cumple')),
-          DropdownMenuItem(value: 'na', child: Text('No aplica')),
+        items: [
+          const DropdownMenuItem(value: 'yes', child: Text('Sí / Cumple')),
+          const DropdownMenuItem(value: 'no', child: Text('No cumple')),
+          const DropdownMenuItem(value: 'na', child: Text('No aplica')),
         ],
         onChanged: (v) {
           _answers[key] = v ?? 'no';
@@ -129,10 +129,10 @@ class _ModulesEvaluationPageState extends ConsumerState<ModulesEvaluationPage> {
       final val = _answers[key] ?? 'C';
       return DropdownButtonFormField<String>(
         value: val,
-        items: const [
-          DropdownMenuItem(value: 'A', child: Text('A')),
-          DropdownMenuItem(value: 'B', child: Text('B')),
-          DropdownMenuItem(value: 'C', child: Text('C')),
+        items: [
+          const DropdownMenuItem(value: 'A', child: Text('A')),
+          const DropdownMenuItem(value: 'B', child: Text('B')),
+          const DropdownMenuItem(value: 'C', child: Text('C')),
         ],
         onChanged: (v) {
           _answers[key] = v ?? 'C';

--- a/lib/features/inspections/new_inspection_wizard.dart
+++ b/lib/features/inspections/new_inspection_wizard.dart
@@ -294,10 +294,10 @@ class _NewInspectionWizardState extends ConsumerState<NewInspectionWizard> {
     if (question.answerType == AnswerType.yn) {
       return DropdownButtonFormField<String>(
         value: _answers[key],
-        items: const [
-          DropdownMenuItem(value: 'yes', child: Text('Sí / Cumple')),
-          DropdownMenuItem(value: 'no', child: Text('No cumple')),
-          DropdownMenuItem(value: 'na', child: Text('No aplica')),
+        items: [
+          const DropdownMenuItem(value: 'yes', child: Text('Sí / Cumple')),
+          const DropdownMenuItem(value: 'no', child: Text('No cumple')),
+          const DropdownMenuItem(value: 'na', child: Text('No aplica')),
         ],
         onChanged: (value) {
           setState(() => _answers[key] = value ?? 'no');
@@ -309,10 +309,10 @@ class _NewInspectionWizardState extends ConsumerState<NewInspectionWizard> {
 
     return DropdownButtonFormField<String>(
       value: _answers[key],
-      items: const [
-        DropdownMenuItem(value: 'A', child: Text('A')),
-        DropdownMenuItem(value: 'B', child: Text('B')),
-        DropdownMenuItem(value: 'C', child: Text('C')),
+      items: [
+        const DropdownMenuItem(value: 'A', child: Text('A')),
+        const DropdownMenuItem(value: 'B', child: Text('B')),
+        const DropdownMenuItem(value: 'C', child: Text('C')),
       ],
       onChanged: (value) {
         setState(() => _answers[key] = value ?? 'C');
@@ -684,14 +684,14 @@ class _NewInspectionWizardState extends ConsumerState<NewInspectionWizard> {
         // 🔹 Dropdown tipo inspección (CORREGIDO)
         DropdownButtonFormField<String>(
           value: _tipoInspeccion,
-          items: const [
-            DropdownMenuItem<String>(
+          items: [
+            const DropdownMenuItem<String>(
                 value: 'comercio_pequeno', child: Text('Comercio pequeño')),
-            DropdownMenuItem<String>(
+            const DropdownMenuItem<String>(
                 value: 'comercio_grande', child: Text('Comercio grande')),
-            DropdownMenuItem<String>(
+            const DropdownMenuItem<String>(
                 value: 'estacion_servicio', child: Text('Estación de servicio')),
-            DropdownMenuItem<String>(
+            const DropdownMenuItem<String>(
                 value: 'industria', child: Text('Industria')),
           ],
           onChanged: (String? value) {
@@ -727,9 +727,11 @@ class _NewInspectionWizardState extends ConsumerState<NewInspectionWizard> {
           value: _subsanadasPrevias,
           decoration: const InputDecoration(
               labelText: '¿Se subsanaron observaciones previas?'),
-          items: const [
-            DropdownMenuItem<bool>(value: true, child: Text('Sí, subsanadas')),
-            DropdownMenuItem<bool>(value: false, child: Text('No se subsanaron')),
+          items: [
+            const DropdownMenuItem<bool>(
+                value: true, child: Text('Sí, subsanadas')),
+            const DropdownMenuItem<bool>(
+                value: false, child: Text('No se subsanaron')),
           ],
           onChanged: (bool? value) =>
               setState(() => _subsanadasPrevias = value),
@@ -741,10 +743,10 @@ class _NewInspectionWizardState extends ConsumerState<NewInspectionWizard> {
           value: _emergenciasUltAnio,
           decoration: const InputDecoration(
               labelText: '¿Emergencias en el último año?'),
-          items: const [
-            DropdownMenuItem<bool>(
+          items: [
+            const DropdownMenuItem<bool>(
                 value: true, child: Text('Sí hubo emergencias')),
-            DropdownMenuItem<bool>(
+            const DropdownMenuItem<bool>(
                 value: false, child: Text('No hubo emergencias')),
           ],
           onChanged: (bool? value) =>


### PR DESCRIPTION
## Summary
- replace const dropdown item lists with non-const lists that contain const menu items to resolve analyzer errors
- remove the unused printing import from the PDF service and rename the local helper used to parse boolean values

## Testing
- not run (CI only)

------
https://chatgpt.com/codex/tasks/task_e_68e068172198833093897f873e92fe60