### PR TITLE
Align evaluation templates with updated scoring

### DIFF
--- a/lib/core/module_templates.dart
+++ b/lib/core/module_templates.dart
@@ -1,3 +1,5 @@
+import 'templates.dart';
+
 class AnswerType {
   static const yn = 'yn';   // Sí / No / N/A -> suma puntos solo con "sí"
   static const abc = 'abc'; // A / B / C     -> usa scoreMap
@@ -28,118 +30,49 @@ class ModuleTemplateSet {
   final List<ModuleDef> modules;
   final int passingScore;
   const ModuleTemplateSet({required this.modules, required this.passingScore});
+
+  int get maxScore => modules.fold(
+        0,
+        (total, module) => total +
+            module.items.fold(0, (subtotal, item) => subtotal + item.points),
+      );
 }
 
-final comercioPequeno = ModuleTemplateSet(
-  passingScore: 70,
-  modules: [
-    ModuleDef(
-      title: 'Módulo No. 1. Sistemas eléctricos',
-      items: [
-        ModuleQuestion(
-          id: 'elec_tablero',
-          text: '¿Tablero con protecciones y señalización?',
-          points: 10,
-          answerType: AnswerType.yn,
-        ),
-        ModuleQuestion(
-          id: 'elec_cableado',
-          text: 'Estado del cableado (A excelente / B aceptable / C deficiente)',
-          points: 10,
-          answerType: AnswerType.abc,
-          scoreMap: {'A': 10, 'B': 5, 'C': 0},
-        ),
-      ],
-    ),
-    ModuleDef(
-      title: 'Módulo No. 2. Vías de evacuación',
-      items: [
-        ModuleQuestion(
-          id: 'vias_salida',
-          text: '¿Salida de emergencia libre y señalizada?',
-          points: 20,
-          answerType: AnswerType.yn,
-        ),
-        ModuleQuestion(
-          id: 'rutas_senial',
-          text: 'Señalización de rutas (A completa / B parcial / C inexistente)',
-          points: 10,
-          answerType: AnswerType.abc,
-          scoreMap: {'A': 10, 'B': 5, 'C': 0},
-        ),
-      ],
-    ),
-  ],
-);
-
-final comercioGrande = ModuleTemplateSet(
-  passingScore: 80,
-  modules: [
-    ModuleDef(
-      title: 'Módulo No. 1. Protección activa',
-      items: [
-        ModuleQuestion(
-          id: 'extintores',
-          text: '¿Extintores suficientes, señalizados y con mantenimiento?',
-          points: 15,
-          answerType: AnswerType.yn,
-        ),
-        ModuleQuestion(
-          id: 'alarmas',
-          text: 'Sistema de alarma (A operativo / B intermitente / C inoperativo)',
-          points: 15,
-          answerType: AnswerType.abc,
-          scoreMap: {'A': 15, 'B': 8, 'C': 0},
-        ),
-      ],
-    ),
-  ],
-);
-
-final estacionServicio = ModuleTemplateSet(
-  passingScore: 85,
-  modules: [
-    ModuleDef(
-      title: 'Módulo No. 1. Seguridad en despacho',
-      items: [
-        ModuleQuestion(
-          id: 'antiderrames',
-          text: '¿Kit antiderrames disponible y completo?',
-          points: 20,
-          answerType: AnswerType.yn,
-        ),
-      ],
-    ),
-  ],
-);
-
-final industria = ModuleTemplateSet(
-  passingScore: 90,
-  modules: [
-    ModuleDef(
-      title: 'Módulo No. 1. Maquinaria',
-      items: [
-        ModuleQuestion(
-          id: 'guardas',
-          text: '¿Guardas y paros de emergencia en máquinas?',
-          points: 20,
-          answerType: AnswerType.yn,
-        ),
-      ],
-    ),
-  ],
-);
+String _moduleTitle(String code) {
+  switch (code) {
+    case 'comercio_pequeno':
+      return 'Checklist comercio pequeño';
+    case 'comercio_mediano':
+      return 'Checklist comercio mediano';
+    case 'comercio_grande':
+      return 'Checklist comercio grande';
+    case 'estacion_servicio':
+      return 'Checklist estación de servicio';
+    case 'industria':
+      return 'Checklist industria';
+    default:
+      return 'Checklist de verificación';
+  }
+}
 
 ModuleTemplateSet templatesByType(String tipo) {
-  switch (tipo) {
-    case 'comercio_grande':
-      return comercioGrande;
-    case 'estacion_servicio':
-      return estacionServicio;
-    case 'industria':
-      return industria;
-    case 'comercio_pequeno':
-    default:
-      return comercioPequeno;
-  }
+  final template = templateByCode(tipo);
+  return ModuleTemplateSet(
+    passingScore: template.passingScore,
+    modules: [
+      ModuleDef(
+        title: _moduleTitle(template.code),
+        items: template.questions
+            .map(
+              (q) => ModuleQuestion(
+                id: q.id,
+                text: q.text,
+                points: q.points,
+                answerType: AnswerType.yn,
+              ),
+            )
+            .toList(growable: false),
+      ),
+    ],
+  );
 }

--- a/lib/core/pdf_service.dart
+++ b/lib/core/pdf_service.dart
@@ -13,6 +13,7 @@ class PdfService {
     required List<Map<String, dynamic>> modules,
     required int totalScore,
     required int passingScore,
+    required int maxScore,
     required bool aprobado,
   }) async {
     final inspection = _InspectionData.fromRaw(
@@ -20,6 +21,7 @@ class PdfService {
       modules: modules,
       totalScore: totalScore,
       passingScore: passingScore,
+      maxScore: maxScore,
       aprobado: aprobado,
     );
 
@@ -471,7 +473,8 @@ class PdfService {
                 'el plazo para la subsanación de los requerimientos contenidos en este informe no podrá exceder de los 30 días calendario contados desde la entrega del informe de inspección.',
               ),
             pw.SizedBox(height: 20),
-            pw.Text('Puntaje total obtenido: ${inspection.totalScore} / ${inspection.passingScore}'),
+            pw.Text(
+                'Puntaje total obtenido: ${inspection.totalScore} / ${inspection.maxScore} (mínimo: ${inspection.passingScore})'),
             pw.Text(
               inspection.aprobado ? 'Resultado: APROBADO' : 'Resultado: NO APROBADO',
               style: pw.TextStyle(
@@ -646,6 +649,7 @@ class _InspectionData {
     required this.modules,
     required this.totalScore,
     required this.passingScore,
+    required this.maxScore,
     required this.aprobado,
   });
 
@@ -663,6 +667,7 @@ class _InspectionData {
   final List<_ModuleData> modules;
   final int totalScore;
   final int passingScore;
+  final int maxScore;
   final bool aprobado;
 
   String get formattedDate => fechaTexto;
@@ -672,6 +677,7 @@ class _InspectionData {
     required List<Map<String, dynamic>> modules,
     required int totalScore,
     required int passingScore,
+    required int maxScore,
     required bool aprobado,
   }) {
     final inspectorMap = base['inspector'] as Map<String, dynamic>? ?? {};
@@ -717,6 +723,7 @@ class _InspectionData {
       modules: modules.map(_ModuleData.fromMap).toList(),
       totalScore: totalScore,
       passingScore: passingScore,
+      maxScore: maxScore,
       aprobado: aprobado,
     );
   }

--- a/lib/core/templates.dart
+++ b/lib/core/templates.dart
@@ -17,55 +17,425 @@ class TemplateDef {
     required this.passingScore,
     required this.questions,
   });
+
+  int get maxScore =>
+      questions.fold(0, (total, question) => total + question.points);
 }
 
 const templates = <TemplateDef>[
   TemplateDef(
     code: 'comercio_pequeno',
     name: 'Comercio pequeño',
-    passingScore: 70,
+    passingScore: 16,
     questions: [
-      Question(id: 'extintores', text: '¿Extintores señalizados y con carga vigente?', points: 15),
-      Question(id: 'salida',     text: '¿Salida de emergencia libre de obstáculos?', points: 20),
-      Question(id: 'inst_elec',  text: '¿Instalación eléctrica en buen estado?',   points: 20),
-      Question(id: 'kit_prim',   text: '¿Botiquín de primeros auxilios disponible?', points: 15),
-      Question(id: 'capacit',    text: '¿Personal capacitado en evacuación?',      points: 10),
+      Question(
+        id: 'extintor_tipo',
+        text: 'Extintor adecuado al tipo de riesgo (mínimo tipo ABC)',
+        points: 2,
+      ),
+      Question(
+        id: 'extintor_vigente',
+        text: 'Extintor vigente, señalado y visible',
+        points: 2,
+      ),
+      Question(
+        id: 'senial_rutas',
+        text: 'Señalización de rutas de salida visible',
+        points: 2,
+      ),
+      Question(
+        id: 'salida_libre',
+        text: 'Salida de emergencia libre de obstáculos',
+        points: 2,
+      ),
+      Question(
+        id: 'senial_emergencia',
+        text: 'Señalización de emergencia visible y sin obstrucciones',
+        points: 2,
+      ),
+      Question(
+        id: 'botiquin',
+        text: 'Botiquín visible y completo',
+        points: 2,
+      ),
+      Question(
+        id: 'iluminacion',
+        text: 'Iluminación de emergencia lista en puntos estratégicos',
+        points: 2,
+      ),
+      Question(
+        id: 'instalaciones_limpias',
+        text: 'Instalaciones limpias sin material inflamable',
+        points: 2,
+      ),
+      Question(
+        id: 'personal_capacitado',
+        text: 'Personal capacitado en emergencias',
+        points: 2,
+      ),
+      Question(
+        id: 'senial_no_fumar',
+        text: 'Señalización de “No fumar” en zonas de riesgo',
+        points: 2,
+      ),
+      Question(
+        id: 'mantenimiento_electrico',
+        text: 'Mantenimiento básico anual en instalaciones eléctricas',
+        points: 2,
+      ),
+      Question(
+        id: 'uso_extintor',
+        text: 'Personal conoce el uso del extintor',
+        points: 2,
+      ),
+    ],
+  ),
+  TemplateDef(
+    code: 'comercio_mediano',
+    name: 'Comercio mediano',
+    passingScore: 23,
+    questions: [
+      Question(
+        id: 'plan_emergencia',
+        text: 'Plan de emergencia visible y firmado',
+        points: 3,
+      ),
+      Question(
+        id: 'senial_rutas',
+        text: 'Señalización de rutas de evacuación',
+        points: 3,
+      ),
+      Question(
+        id: 'extintores_suficientes',
+        text: 'Extintores suficientes según el área y riesgo',
+        points: 3,
+      ),
+      Question(
+        id: 'recarga_extintores',
+        text: 'Fecha de recarga vigente y accesible',
+        points: 3,
+      ),
+      Question(
+        id: 'salida_libre',
+        text: 'Salida de emergencia libre y sin sobrecarga',
+        points: 3,
+      ),
+      Question(
+        id: 'brigada_operativa',
+        text: 'Brigada de emergencia operativa',
+        points: 3,
+      ),
+      Question(
+        id: 'botiquin_completo',
+        text: 'Botiquín y kit de primeros auxilios completo',
+        points: 3,
+      ),
+      Question(
+        id: 'capacitaciones',
+        text: 'Personal capacitado en evacuaciones y uso de extintores',
+        points: 3,
+      ),
+      Question(
+        id: 'materiales_combustibles',
+        text: 'No existen materiales combustibles junto a fuentes de calor',
+        points: 3,
+      ),
+      Question(
+        id: 'senales_fotoluminiscentes',
+        text: 'Señales fotoluminiscentes visibles',
+        points: 3,
+      ),
+      Question(
+        id: 'orden_limpieza',
+        text: 'Se conserva orden y limpieza general',
+        points: 2,
+      ),
     ],
   ),
   TemplateDef(
     code: 'comercio_grande',
     name: 'Comercio grande',
-    passingScore: 80,
+    passingScore: 40,
     questions: [
-      Question(id: 'extintores', text: '¿Extintores suficientes y mantenidos?', points: 15),
-      Question(id: 'hidrantes',  text: '¿Hidrantes internos operativos?',       points: 15),
-      Question(id: 'rutas',      text: '¿Rutas de evacuación señalizadas?',     points: 20),
-      Question(id: 'alarmas',    text: '¿Sistema de alarma funciona?',          points: 15),
-      Question(id: 'aforo',      text: '¿Control de aforo y salidas adecuadas?',points: 15),
+      Question(
+        id: 'alarma_automatica',
+        text: 'Sistema de detección y alarma automática funcionando',
+        points: 4,
+      ),
+      Question(
+        id: 'rociadores',
+        text: 'Sistema de rociadores automáticos (si aplica) en funcionamiento',
+        points: 4,
+      ),
+      Question(
+        id: 'senializacion_completa',
+        text: 'Señalización completa de evacuación y salidas',
+        points: 4,
+      ),
+      Question(
+        id: 'extintores_visibles',
+        text: 'Extintores suficientes y visibles por área',
+        points: 4,
+      ),
+      Question(
+        id: 'brigadas',
+        text: 'Personal entrenado en emergencias y brigadas internas',
+        points: 4,
+      ),
+      Question(
+        id: 'luces_emergencia',
+        text: 'Luces de emergencia en pasillos y zonas críticas',
+        points: 3,
+      ),
+      Question(
+        id: 'hidrantes',
+        text: 'Hidrantes internos y externos operativos',
+        points: 3,
+      ),
+      Question(
+        id: 'rutas_actualizadas',
+        text: 'Señalización de rutas de evacuación actualizada',
+        points: 3,
+      ),
+      Question(
+        id: 'cableado_certificado',
+        text: 'Cableado certificado y sin sobrecarga',
+        points: 3,
+      ),
+      Question(
+        id: 'equipos_mantenimiento',
+        text: 'Equipos eléctricos con mantenimiento al día',
+        points: 3,
+      ),
+      Question(
+        id: 'almacenamiento_escaleras',
+        text: 'No hay almacenamiento en escaleras o pasillos',
+        points: 3,
+      ),
+      Question(
+        id: 'senales_no_fumar',
+        text: 'Señales de “No fumar / Material inflamable” visibles',
+        points: 3,
+      ),
+      Question(
+        id: 'rutas_libres',
+        text: 'Rutas libres y señalizadas en todas las áreas',
+        points: 3,
+      ),
+      Question(
+        id: 'plan_por_zonas',
+        text: 'Plan de emergencias general por zonas',
+        points: 3,
+      ),
+      Question(
+        id: 'registros_inspeccion',
+        text: 'Registros de inspecciones vigentes y firmados',
+        points: 3,
+      ),
+      Question(
+        id: 'area_reunion',
+        text: 'Área de reunión externa señalizada',
+        points: 3,
+      ),
     ],
   ),
   TemplateDef(
     code: 'estacion_servicio',
     name: 'Estación de servicio',
-    passingScore: 85,
+    passingScore: 60,
     questions: [
-      Question(id: 'tierra',     text: '¿Sistemas de puesta a tierra certificados?', points: 20),
-      Question(id: 'derrame',    text: '¿Kit antiderrames disponible?',              points: 20),
-      Question(id: 'senial',     text: '¿Señalización de seguridad completa?',       points: 15),
-      Question(id: 'ext_esp',    text: '¿Extintores y espuma adecuados?',            points: 20),
-      Question(id: 'zonas',      text: '¿Zonas peligrosas demarcadas?',              points: 10),
+      Question(
+        id: 'plan_emergencia',
+        text: 'Plan de emergencia y contingencia vigente',
+        points: 5,
+      ),
+      Question(
+        id: 'personal_capacitado',
+        text: 'Personal capacitado en manejo de incidentes y derrames',
+        points: 5,
+      ),
+      Question(
+        id: 'extintores_operativos',
+        text: 'Extintores tipo PQS y CO₂ operativos y visibles',
+        points: 5,
+      ),
+      Question(
+        id: 'sistema_corte',
+        text: 'Sistema de corte de energía y emergencias funcionando',
+        points: 5,
+      ),
+      Question(
+        id: 'area_sin_ignicion',
+        text: 'Área libre de fuentes de ignición',
+        points: 5,
+      ),
+      Question(
+        id: 'senales_prohibido_fumar',
+        text: 'Señalización de “Prohibido fumar” visible y suficiente',
+        points: 5,
+      ),
+      Question(
+        id: 'canaletas_limpias',
+        text: 'Canaletas de almacenamiento limpias y funcionales (sin fugas)',
+        points: 5,
+      ),
+      Question(
+        id: 'tanques_limpios',
+        text: 'Tanques de almacenamiento limpios y funcionales (sin fugas)',
+        points: 5,
+      ),
+      Question(
+        id: 'kit_antiderrames',
+        text: 'Kit antiderrames y materiales absorbentes disponible',
+        points: 5,
+      ),
+      Question(
+        id: 'supervision_mangueras',
+        text: 'Supervisión diaria de mangueras y válvulas',
+        points: 5,
+      ),
+      Question(
+        id: 'distancias_reglamentarias',
+        text: 'Distancias reglamentarias entre surtidores y zonas de servicio',
+        points: 5,
+      ),
+      Question(
+        id: 'senalizacion_horizontal',
+        text: 'Señalización horizontal y vertical reglamentaria',
+        points: 5,
+      ),
+      Question(
+        id: 'areas_tanques_limpias',
+        text: 'Áreas de tanques y zonas críticas limpias y libres de residuos',
+        points: 5,
+      ),
+      Question(
+        id: 'drenajes',
+        text: 'Drenajes y sistemas de contención limpios y funcionales',
+        points: 5,
+      ),
+      Question(
+        id: 'mantenimiento_surtidores',
+        text: 'Surtidores con mantenimiento y registros al día',
+        points: 5,
+      ),
+      Question(
+        id: 'revision_diaria',
+        text: 'Revisión diaria de áreas y accesorios disponibles',
+        points: 5,
+      ),
+      Question(
+        id: 'limpieza_general',
+        text: 'Instalaciones limpias y libres de derrames',
+        points: 5,
+      ),
     ],
   ),
   TemplateDef(
     code: 'industria',
     name: 'Industria',
-    passingScore: 90,
+    passingScore: 80,
     questions: [
-      Question(id: 'plan',       text: '¿Plan de emergencias actualizado?',      points: 20),
-      Question(id: 'epi',        text: '¿EPP adecuado para las tareas?',         points: 15),
-      Question(id: 'maquinas',   text: '¿Guardas y paros de emergencia?',        points: 20),
-      Question(id: 'almacen',    text: '¿Almacenamiento de químicos correcto?',  points: 20),
-      Question(id: 'capacit',    text: '¿Capacitaciones registradas?',           points: 15),
+      Question(
+        id: 'evaluacion_riesgo',
+        text: 'Evaluación de riesgo de incendio documentada',
+        points: 5,
+      ),
+      Question(
+        id: 'brigada_interna',
+        text: 'Brigada interna activa y capacitada',
+        points: 5,
+      ),
+      Question(
+        id: 'sistemas_deteccion',
+        text: 'Sistemas automáticos (espuma, CO₂ o rociadores) funcionando',
+        points: 5,
+      ),
+      Question(
+        id: 'extintores_funcionales',
+        text: 'Extintores suficientes y con mantenimiento vigente',
+        points: 5,
+      ),
+      Question(
+        id: 'deteccion_gases',
+        text: 'Detectores de gases o vapores inflamables operativos',
+        points: 5,
+      ),
+      Question(
+        id: 'permiso_trabajo',
+        text: 'Permiso de trabajo en caliente implementado',
+        points: 5,
+      ),
+      Question(
+        id: 'senalizacion_maquinaria',
+        text: 'Señalización completa y visible en todas las áreas',
+        points: 5,
+      ),
+      Question(
+        id: 'capacitacion_personal',
+        text: 'Personal capacitado en manejo de emergencias',
+        points: 5,
+      ),
+      Question(
+        id: 'sistemas_ventilacion',
+        text: 'Sistemas de ventilación y extracción funcionando',
+        points: 5,
+      ),
+      Question(
+        id: 'almacenamiento_quimicos',
+        text: 'Almacenamiento seguro de químicos y combustibles',
+        points: 5,
+      ),
+      Question(
+        id: 'mantenimiento_maquinaria',
+        text: 'Mantenimiento preventivo de maquinaria documentado',
+        points: 5,
+      ),
+      Question(
+        id: 'rutas_evacuacion',
+        text: 'Rutas de evacuación señalizadas y libres de obstáculos',
+        points: 5,
+      ),
+      Question(
+        id: 'sistema_iluminacion',
+        text: 'Sistema de iluminación de emergencia operativo',
+        points: 5,
+      ),
+      Question(
+        id: 'politica_no_fumar',
+        text: 'Política de “No fumar / Material inflamable” visible',
+        points: 5,
+      ),
+      Question(
+        id: 'control_polvoy_particulas',
+        text: 'Control de polvo o partículas combustibles',
+        points: 5,
+      ),
+      Question(
+        id: 'gestion_residuos',
+        text: 'Gestión adecuada de residuos peligrosos',
+        points: 5,
+      ),
+      Question(
+        id: 'proteccion_personal',
+        text: 'Elementos de protección personal disponibles y en uso',
+        points: 5,
+      ),
+      Question(
+        id: 'control_transporte',
+        text: 'Plan de acceso y transporte de materiales peligrosos',
+        points: 5,
+      ),
+      Question(
+        id: 'senalizacion_areas_carga',
+        text: 'Señalización en áreas de carga y descarga',
+        points: 5,
+      ),
+      Question(
+        id: 'plan_emergencia_industrial',
+        text: 'Plan de emergencias por vehículos de carga y visitantes',
+        points: 5,
+      ),
     ],
   ),
 ];
@@ -134,11 +504,16 @@ String normalizeTemplateCode(String? code) {
     case 'grande':
     case 'gran_comercio':
       return 'comercio_grande';
+    case 'comercio_mediano':
+    case 'comerciomediano':
+    case 'mediano':
+      return 'comercio_mediano';
     case 'estacion_servicio':
     case 'estacionservicio':
     case 'estacion_de_servicio':
     case 'estacion':
     case 'gasolinera':
+    case 'eds':
       return 'estacion_servicio';
     case 'industria':
     case 'industrial':

--- a/lib/features/inspections/inspections_list_page.dart
+++ b/lib/features/inspections/inspections_list_page.dart
@@ -21,12 +21,18 @@ final myInspectionsProvider =
 class InspectionsListPage extends ConsumerWidget {
   const InspectionsListPage({super.key});
 
+  int _toInt(dynamic value) {
+    if (value is int) return value;
+    if (value is double) return value.round();
+    return int.tryParse(value.toString()) ?? 0;
+  }
+
   bool _isApproved(Map<String, dynamic> row) {
     try {
-      final template = (row['tipo_inspeccion'] ?? '').toString();
-      final score = (row['resultado']?['puntaje_total'] ?? 0) as int;
-      final t = templates.firstWhere((e) => e.code == template);
-      return score >= t.passingScore;
+      final templateCode = (row['tipo_inspeccion'] ?? '').toString();
+      final template = templateByCode(templateCode);
+      final score = _toInt(row['resultado']?['puntaje_total']);
+      return score >= template.passingScore;
     } catch (_) {
       return false;
     }
@@ -50,18 +56,19 @@ class InspectionsListPage extends ConsumerWidget {
               final r = rows[i];
               final name = r['nombre_comercial'] ?? '—';
               final radicado = r['radicado'] ?? '—';
-              final score = (r['resultado']?['puntaje_total'] ?? 0) as int;
-              final template = r['tipo_inspeccion'] ?? '';
+              final templateCode = (r['tipo_inspeccion'] ?? '').toString();
+              final template = templateByCode(templateCode);
+              final score = _toInt(r['resultado']?['puntaje_total']);
               final date = (r['fecha_inspeccion'] ?? '').toString();
               final ok = _isApproved(r);
 
               return ListTile(
                 title: Text(name),
-                subtitle: Text('Radicado: $radicado • $template • $date'),
+                subtitle: Text('Radicado: $radicado • ${template.name} • $date'),
                 trailing: Column(
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
-                    Text('$score pts'),
+                    Text('$score / ${template.maxScore} pts'),
                     Text(ok ? 'APROBADO' : 'NO APROBADO',
                         style: TextStyle(
                           color: ok ? Colors.green : Colors.red,

--- a/lib/features/inspections/modules_evaluation_page.dart
+++ b/lib/features/inspections/modules_evaluation_page.dart
@@ -224,6 +224,7 @@ class _ModulesEvaluationPageState extends ConsumerState<ModulesEvaluationPage> {
         tipoInspeccion: _tipoNormalizado,
         modules: modulesJson,
         passingScore: _tpl.passingScore,
+        maxScore: _tpl.maxScore,
         totalScore: _score,
         aprobado: aprobado,
       ),
@@ -238,7 +239,7 @@ class _ModulesEvaluationPageState extends ConsumerState<ModulesEvaluationPage> {
         padding: const EdgeInsets.all(16),
         children: [
           Text(
-            'Puntaje mínimo: ${_tpl.passingScore} — Actual: $_score',
+            'Puntaje mínimo: ${_tpl.passingScore} / Máximo: ${_tpl.maxScore} — Actual: $_score',
             style: Theme.of(context).textTheme.titleMedium,
           ),
           const SizedBox(height: 12),

--- a/lib/features/inspections/summary_conclusion_page.dart
+++ b/lib/features/inspections/summary_conclusion_page.dart
@@ -10,6 +10,7 @@ class SummaryConclusionPage extends ConsumerStatefulWidget {
   final String tipoInspeccion;                         // tipo seleccionado
   final List<Map<String, dynamic>> modules;            // módulos armados en Hoja 2
   final int passingScore;
+  final int maxScore;
   final int totalScore;
   final bool aprobado;
 
@@ -19,6 +20,7 @@ class SummaryConclusionPage extends ConsumerStatefulWidget {
     required this.tipoInspeccion,
     required this.modules,
     required this.passingScore,
+    required this.maxScore,
     required this.totalScore,
     required this.aprobado,
   });
@@ -56,6 +58,7 @@ class _SummaryConclusionPageState extends ConsumerState<SummaryConclusionPage> {
           'puntaje_total': widget.totalScore,   // 👈 ahora sí el real
           'aprobado': aprobado,
           'puntaje_minimo': widget.passingScore,
+          'puntaje_maximo': widget.maxScore,
         },
       };
 
@@ -82,6 +85,7 @@ class _SummaryConclusionPageState extends ConsumerState<SummaryConclusionPage> {
         modules: widget.modules,
         totalScore: widget.totalScore,
         passingScore: widget.passingScore,
+        maxScore: widget.maxScore,
         aprobado: widget.aprobado,
       );
       await Printing.sharePdf(bytes: bytes, filename: 'informe_inspeccion.pdf');
@@ -124,7 +128,7 @@ class _SummaryConclusionPageState extends ConsumerState<SummaryConclusionPage> {
         padding: const EdgeInsets.all(16),
         children: [
           Text(
-            'Puntaje total: ${widget.totalScore} / Mínimo: ${widget.passingScore}',
+            'Puntaje total: ${widget.totalScore} / ${widget.maxScore} (mínimo: ${widget.passingScore})',
             style: Theme.of(context).textTheme.titleLarge,
           ),
           const SizedBox(height: 8),


### PR DESCRIPTION
## Summary
- redefine checklist templates for comercio pequeño/mediano/grande, estaciones de servicio y la industria con los puntajes y mínimos solicitados
- generar los módulos de evaluación a partir de esas plantillas y exponer el puntaje máximo para cada tipo de inspección
- mostrar y almacenar el puntaje máximo en la evaluación, el resumen, el detalle, las listas y el PDF

## Testing
- flutter analyze *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3dde9da40833083591864c48b87b3