### PR TITLE
Pass max score through summary flow

### DIFF
--- a/lib/features/inspections/evaluation_page.dart
+++ b/lib/features/inspections/evaluation_page.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-import '../../core/templates.dart';
+import '../../core/module_templates.dart';
 
 /// Dropdown a prueba de crashes:
 class SafeDropdownFormField<T> extends StatelessWidget {

--- a/lib/features/inspections/modules_evaluation_page.dart
+++ b/lib/features/inspections/modules_evaluation_page.dart
@@ -6,7 +6,7 @@ import 'package:image_picker/image_picker.dart';
 import '../../core/providers.dart';
 import '../../core/storage.dart';
 import 'summary_conclusion_page.dart';
-import '../../core/templates.dart';
+import '../../core/module_templates.dart';
 
 class ModulesEvaluationPage extends ConsumerStatefulWidget {
   final Map<String, dynamic> baseData;
@@ -204,6 +204,7 @@ class _ModulesEvaluationPageState extends ConsumerState<ModulesEvaluationPage> {
         tipoInspeccion: _tipoNormalizado,
         modules: modulesJson,
         passingScore: _tpl.passingScore,
+        maxScore: _tpl.maxScore,
         totalScore: _score,
         aprobado: aprobado,
       ),

--- a/lib/features/inspections/new_inspection_wizard.dart
+++ b/lib/features/inspections/new_inspection_wizard.dart
@@ -9,7 +9,6 @@ import 'package:image_picker/image_picker.dart';
 import '../../core/module_templates.dart';
 import '../../core/providers.dart';
 import '../../core/storage.dart';
-import '../../core/templates.dart';
 
 /// Wizard de tres pasos para crear o editar inspecciones.
 ///

--- a/lib/features/inspections/summary_conclusion_page.dart
+++ b/lib/features/inspections/summary_conclusion_page.dart
@@ -9,6 +9,7 @@ class SummaryConclusionPage extends ConsumerStatefulWidget {
   final String tipoInspeccion;
   final List<Map<String, dynamic>> modules;
   final int passingScore;
+  final int maxScore;
   final int totalScore;
   final bool aprobado;
 
@@ -18,6 +19,7 @@ class SummaryConclusionPage extends ConsumerStatefulWidget {
     required this.tipoInspeccion,
     required this.modules,
     required this.passingScore,
+    required this.maxScore,
     required this.totalScore,
     required this.aprobado,
   });
@@ -53,6 +55,7 @@ class _SummaryConclusionPageState
         'modules': widget.modules,
         'resultado': {
           'puntaje_total': widget.totalScore,
+          'puntaje_maximo': widget.maxScore,
           'aprobado': aprobado,
         },
       };
@@ -79,6 +82,7 @@ class _SummaryConclusionPageState
         modules: widget.modules,
         totalScore: widget.totalScore,
         passingScore: widget.passingScore,
+        maxScore: widget.maxScore,
         aprobado: widget.aprobado,
       );
       await Printing.sharePdf(


### PR DESCRIPTION
## Summary
- store the module template max score on the summary page so it can be persisted and exported
- pass the max score when pushing the summary screen from the modules evaluation flow

## Testing
- Not run (Flutter/Dart SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e3f2743fa083309fe6da3b5650d1ed