### PR TITLE
Fix modules evaluation and summary issues

### DIFF
--- a/lib/features/inspections/modules_evaluation_page.dart
+++ b/lib/features/inspections/modules_evaluation_page.dart
@@ -92,6 +92,9 @@ class _ModulesEvaluationPageState extends ConsumerState<ModulesEvaluationPage> {
         userId: user.id,
         questionId: key.replaceAll('_', '/'),
       );
+
+      if (!mounted) return;
+
       final list = _photos[key] ?? <Map<String, String>>[];
       list.add({'url': url, 'observacion': ''});
       setState(() => _photos[key] = list);
@@ -202,7 +205,7 @@ class _ModulesEvaluationPageState extends ConsumerState<ModulesEvaluationPage> {
       builder: (_) => SummaryConclusionPage(
         baseData: widget.baseData,
         tipoInspeccion: _tipoNormalizado,
-        modules: modulesJson,
+        modulesData: modulesJson,
         passingScore: _tpl.passingScore,
         maxScore: _tpl.maxScore,
         totalScore: _score,

--- a/lib/features/inspections/summary_conclusion_page.dart
+++ b/lib/features/inspections/summary_conclusion_page.dart
@@ -7,7 +7,7 @@ import '../../core/providers.dart';
 class SummaryConclusionPage extends ConsumerStatefulWidget {
   final Map<String, dynamic> baseData;
   final String tipoInspeccion;
-  final List<Map<String, dynamic>> modules;
+  final List<Map<String, dynamic>> modulesData;
   final int passingScore;
   final int maxScore;
   final int totalScore;
@@ -17,7 +17,7 @@ class SummaryConclusionPage extends ConsumerStatefulWidget {
     super.key,
     required this.baseData,
     required this.tipoInspeccion,
-    required this.modules,
+    required this.modulesData,
     required this.passingScore,
     required this.maxScore,
     required this.totalScore,
@@ -52,7 +52,7 @@ class _SummaryConclusionPageState
         'foto_fachada_url': widget.baseData['foto_fachada_url'],
         'visita_anterior': widget.baseData['visita_anterior'],
         'tipo_inspeccion': widget.tipoInspeccion,
-        'modules': widget.modules,
+        'modules': widget.modulesData,
         'resultado': {
           'puntaje_total': widget.totalScore,
           'puntaje_maximo': widget.maxScore,
@@ -79,7 +79,7 @@ class _SummaryConclusionPageState
     try {
       final bytes = await PdfService.buildInspectionPdf(
         base: widget.baseData,
-        modules: widget.modules,
+        modules: widget.modulesData,
         totalScore: widget.totalScore,
         passingScore: widget.passingScore,
         maxScore: widget.maxScore,
@@ -164,7 +164,7 @@ class _SummaryConclusionPageState
                   )),
           const SizedBox(height: 10),
 
-          for (final module in widget.modules) ...[
+          for (final module in widget.modulesData) ...[
             Card(
               margin: const EdgeInsets.only(bottom: 12),
               child: Padding(


### PR DESCRIPTION
## Summary
- guard photo uploads against unmounted states before updating UI or showing snackbars
- rename summary page module payload to avoid constructor name conflicts and use the new field throughout

## Testing
- not run (environment lacks Flutter/Dart SDK)


------
https://chatgpt.com/codex/tasks/task_e_68e4116d5000833086c3df9cc39d2da5