### PR TITLE
Add named summary route for modules flow

### DIFF
--- a/lib/core/app_router.dart
+++ b/lib/core/app_router.dart
@@ -10,6 +10,22 @@ import '../features/home/home_page.dart';
 import '../features/profile/profile_page.dart';
 import '../features/inspections/inspections_list_page.dart';
 import '../features/inspections/new_inspection_wizard.dart';
+import '../features/inspections/summary_conclusion_page.dart';
+
+class Routes {
+  const Routes._();
+
+  static const String login = 'login';
+  static const String home = 'home';
+  static const String profile = 'profile';
+  static const String inspections = 'inspections';
+  static const String inspectionsStart = 'inspections_start';
+  static const String inspectionsNew = 'inspections_new';
+  static const String inspectionsEdit = 'inspections_edit';
+
+  // ignore: constant_identifier_names
+  static const String pagina_aval_anual = 'pagina_aval_anual';
+}
 
 // --- Utilidad para refrescar GoRouter cuando cambia el auth ---
 class GoRouterRefreshStream extends ChangeNotifier {
@@ -48,33 +64,40 @@ final goRouterProvider = Provider<GoRouter>((ref) {
     routes: [
       GoRoute(
         path: '/login',
+        name: Routes.login,
         builder: (context, state) => const LoginPage(),
       ),
       GoRoute(
         path: '/home',
+        name: Routes.home,
         builder: (context, state) => const HomePage(),
       ),
       GoRoute(
         path: '/profile',
+        name: Routes.profile,
         builder: (context, state) => const ProfilePage(),
       ),
       GoRoute(
         path: '/inspections',
+        name: Routes.inspections,
         builder: (context, state) => const InspectionsListPage(),
       ),
       // Nueva inspección: siempre inicia en Hoja 1 del wizard
       GoRoute(
         path: '/inspections/start',
+        name: Routes.inspectionsStart,
         builder: (context, state) => const NewInspectionWizard(),
       ),
       // (opcional) Crear directo con wizard vacío
       GoRoute(
         path: '/inspections/new',
+        name: Routes.inspectionsNew,
         builder: (context, state) => const NewInspectionWizard(),
       ),
       // (opcional) Editar por id via extra
       GoRoute(
         path: '/inspections/:id/edit',
+        name: Routes.inspectionsEdit,
         builder: (context, state) {
           final extra = state.extra;
           Map<String, dynamic>? existing;
@@ -86,6 +109,21 @@ final goRouterProvider = Provider<GoRouter>((ref) {
             existing: existing,
             inspectionId: state.pathParameters['id'],
           );
+        },
+      ),
+      GoRoute(
+        path: '/inspections/summary',
+        name: Routes.pagina_aval_anual,
+        builder: (context, state) {
+          final extra = state.extra;
+          if (extra is! SummaryConclusionArgs) {
+            return const Scaffold(
+              body: Center(
+                child: Text('Datos de inspección no disponibles'),
+              ),
+            );
+          }
+          return SummaryConclusionPage(data: extra);
         },
       ),
     ],

--- a/lib/features/inspections/modules_evaluation_page.dart
+++ b/lib/features/inspections/modules_evaluation_page.dart
@@ -2,11 +2,13 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:image_picker/image_picker.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../core/providers.dart';
 import '../../core/storage.dart';
 import 'summary_conclusion_page.dart';
 import '../../core/module_templates.dart';
+import '../../core/app_router.dart';
 
 class ModulesEvaluationPage extends ConsumerStatefulWidget {
   final Map<String, dynamic> baseData;
@@ -201,19 +203,18 @@ class _ModulesEvaluationPageState extends ConsumerState<ModulesEvaluationPage> {
 
     final aprobado = _score >= _tpl.passingScore;
 
-    Navigator.of(context).push(MaterialPageRoute(
-      builder: (_) => SummaryConclusionPage(
-        data: SummaryConclusionArgs(
-          baseData: widget.baseData,
-          tipoInspeccion: _tipoNormalizado,
-          modules: modulesJson,
-          passingScore: _tpl.passingScore,
-          maxScore: _tpl.maxScore,
-          totalScore: _score,
-          aprobado: aprobado,
-        ),
+    context.pushNamed(
+      Routes.pagina_aval_anual,
+      extra: SummaryConclusionArgs(
+        baseData: widget.baseData,
+        tipoInspeccion: _tipoNormalizado,
+        modules: modulesJson,
+        passingScore: _tpl.passingScore,
+        maxScore: _tpl.maxScore,
+        totalScore: _score,
+        aprobado: aprobado,
       ),
-    ));
+    );
   }
 
   @override


### PR DESCRIPTION
## Summary
- introduce a `Routes` helper with named routes and register a dedicated summary route in the app router
- wire the new summary route to `SummaryConclusionPage`, handling missing navigation data gracefully
- update the modules evaluation step to navigate via the new named route instead of a manual `MaterialPageRoute`

## Testing
- not run (Flutter tooling not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e4185119e483309b952214df5bd5e9