### PR TITLE
Update inspection templates for staircase and service station checks

### DIFF
--- a/lib/core/module_templates.dart
+++ b/lib/core/module_templates.dart
@@ -8,6 +8,9 @@ class ModuleQuestion {
   final AnswerType answerType;
   final int points;
   final Map<String, int>? scoreMap;
+  final String? yesLabel;
+  final String? noLabel;
+  final String? naLabel;
 
   const ModuleQuestion({
     required this.id,
@@ -15,6 +18,9 @@ class ModuleQuestion {
     required this.answerType,
     required this.points,
     this.scoreMap,
+    this.yesLabel,
+    this.noLabel,
+    this.naLabel,
   });
 
   int get maxAchievablePoints {
@@ -178,6 +184,51 @@ final comercioGrandeTemplate = _makeTemplate(
         ),
       ],
     ),
+    const ModuleTemplate(
+      title: 'Escaleras y accesos seguros',
+      items: [
+        ModuleQuestion(
+          id: 'cintas_antideslizantes',
+          text:
+              '¿Las escaleras cuentan con cintas antideslizantes en todos los peldaños?',
+          answerType: AnswerType.yn,
+          points: 10,
+          yesLabel: 'Cuenta',
+          noLabel: 'No cuenta',
+          naLabel: 'No aplica',
+        ),
+        ModuleQuestion(
+          id: 'cintas_estado',
+          text:
+              '¿Las cintas antideslizantes están firmes, sin desprendimientos ni desgaste?',
+          answerType: AnswerType.yn,
+          points: 10,
+          yesLabel: 'Cuenta',
+          noLabel: 'No cuenta',
+          naLabel: 'No aplica',
+        ),
+        ModuleQuestion(
+          id: 'pasamanos',
+          text:
+              '¿Las escaleras tienen pasamanos continuos y a la altura reglamentaria?',
+          answerType: AnswerType.yn,
+          points: 10,
+          yesLabel: 'Cuenta',
+          noLabel: 'No cuenta',
+          naLabel: 'No aplica',
+        ),
+        ModuleQuestion(
+          id: 'pasamanos_condicion',
+          text:
+              '¿Los pasamanos están firmes, sin juego y con terminales seguros?',
+          answerType: AnswerType.yn,
+          points: 10,
+          yesLabel: 'Cuenta',
+          noLabel: 'No cuenta',
+          naLabel: 'No aplica',
+        ),
+      ],
+    ),
   ],
 );
 
@@ -205,13 +256,22 @@ final estacionServicioTemplate = _makeTemplate(
         ),
         ModuleQuestion(
           id: 'tanques',
-          text: '¿Los tanques de almacenamiento cumplen con medidas reglamentarias?',
+          text:
+              '¿Los tanques de almacenamiento cumplen con medidas reglamentarias y mantenimiento vigente?',
           answerType: AnswerType.yn,
           points: 10,
         ),
         ModuleQuestion(
           id: 'canaletas',
-          text: '¿Las canaletas antiderrames están limpias y funcionales?',
+          text:
+              '¿Las canaletas contra derrames están completas en longitud y en buen estado?',
+          answerType: AnswerType.yn,
+          points: 10,
+        ),
+        ModuleQuestion(
+          id: 'tanques_aforo',
+          text:
+              '¿Los tanques de aforo tienen calibración, protecciones y registros actualizados?',
           answerType: AnswerType.yn,
           points: 10,
         ),

--- a/lib/features/inspections/new_inspection_wizard.dart
+++ b/lib/features/inspections/new_inspection_wizard.dart
@@ -290,16 +290,22 @@ class _NewInspectionWizardState extends ConsumerState<NewInspectionWizard> {
   }
 
   Widget _buildAnswerField(ModuleQuestion question, String key) {
+    final defaultValue = question.answerType == AnswerType.yn ? 'no' : 'C';
+    final currentValue = _answers[key] ?? defaultValue;
+
     if (question.answerType == AnswerType.yn) {
+      final yesLabel = question.yesLabel ?? 'Sí / Cumple';
+      final noLabel = question.noLabel ?? 'No cumple';
+      final naLabel = question.naLabel ?? 'No aplica';
       return DropdownButtonFormField<String>(
-        value: _answers[key],
+        value: currentValue,
         items: [
-          const DropdownMenuItem(value: 'yes', child: Text('Sí / Cumple')),
-          const DropdownMenuItem(value: 'no', child: Text('No cumple')),
-          const DropdownMenuItem(value: 'na', child: Text('No aplica')),
+          DropdownMenuItem(value: 'yes', child: Text(yesLabel)),
+          DropdownMenuItem(value: 'no', child: Text(noLabel)),
+          DropdownMenuItem(value: 'na', child: Text(naLabel)),
         ],
         onChanged: (value) {
-          setState(() => _answers[key] = value ?? 'no');
+          setState(() => _answers[key] = value ?? defaultValue);
           _recalculateScore();
         },
         decoration: const InputDecoration(labelText: 'Resultado'),
@@ -307,14 +313,14 @@ class _NewInspectionWizardState extends ConsumerState<NewInspectionWizard> {
     }
 
     return DropdownButtonFormField<String>(
-      value: _answers[key],
+      value: currentValue,
       items: [
         const DropdownMenuItem(value: 'A', child: Text('A')),
         const DropdownMenuItem(value: 'B', child: Text('B')),
         const DropdownMenuItem(value: 'C', child: Text('C')),
       ],
       onChanged: (value) {
-        setState(() => _answers[key] = value ?? 'C');
+        setState(() => _answers[key] = value ?? defaultValue);
         _recalculateScore();
       },
       decoration: const InputDecoration(labelText: 'Resultado (A/B/C)'),


### PR DESCRIPTION
## Summary
- add staircase safety questions with Cuenta/No cuenta options to the large commerce evaluation
- extend the service station template to verify spill gutters and aforo tank compliance
- support custom yes/no labels and ABC scoring across module evaluation flows

## Testing
- Not run (environment lacks Flutter/Dart tooling)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914cc64f2e883309a11261a0fa4a04b)