### PR TITLE
Corrige la compilación del membrete PDF

### DIFF
--- a/lib/core/pdf_service.dart
+++ b/lib/core/pdf_service.dart
@@ -55,8 +55,8 @@ class PdfService {
               left: 5,
               top: 5,
               right: 5,
-              height: 36,
               child: pw.Container(
+                height: 36,
                 color: institutionalBlue,
                 padding: const pw.EdgeInsets.symmetric(horizontal: 10, vertical: 4),
                 child: pw.Row(
@@ -93,13 +93,21 @@ class PdfService {
                 ),
               ),
             ),
-            pw.Positioned(left: 5, top: 41, right: 5, height: 2, child: pw.Container(color: institutionalRed)),
+            pw.Positioned(
+              left: 5,
+              top: 41,
+              right: 5,
+              child: pw.SizedBox(
+                height: 2,
+                child: pw.Container(color: institutionalRed),
+              ),
+            ),
             pw.Positioned(
               left: 5,
               right: 5,
               bottom: 5,
-              height: 31,
               child: pw.Container(
+                height: 31,
                 color: institutionalBlue,
                 padding: const pw.EdgeInsets.symmetric(horizontal: 10, vertical: 4),
                 child: pw.Column(


### PR DESCRIPTION
## Corrección

- Sustituye los tres parámetros `height` no admitidos por `pw.Positioned` en `pdf 3.11.3`.
- Conserva las mismas alturas mediante `pw.Container` y `pw.SizedBox` internos.
- No modifica contenido, medidas visuales, tablas, textos ni lógica del informe.

## Causa

La versión instalada del paquete PDF solo admite `left`, `top`, `right` y `bottom` en `Positioned`.

## Verificación

Se revisó directamente la API instalada de `pdf 3.11.3` y se confirmó que ya no existe ningún uso inválido de `height` en los elementos `Positioned` del membrete.