### PR TITLE
Compartir inspecciones en modo seguro

### DIFF
--- a/lib/core/module_templates.dart
+++ b/lib/core/module_templates.dart
@@ -109,7 +109,7 @@ final estacionServicioTemplate = _makeTemplate(
         ModuleQuestion(id: "islas_abastecimiento", text: "¿Las islas de abastecimiento permanecen libres de acumulación de materiales combustibles?", answerType: AnswerType.yn, points: 4),
         ModuleQuestion(id: "corte_emergencia", text: "¿Existen dispositivos claramente identificados para suspensión o corte de emergencia del suministro?", answerType: AnswerType.yn, points: 7),
         ModuleQuestion(id: "parada_emergencia", text: "¿Los dispositivos de parada de emergencia se encuentran accesibles y operativos?", answerType: AnswerType.yn, points: 6),
-        ModuleQuestion(id: "fuentes_ignicion", text: "¿Se controla adecuadamente la presencia de fuentes de ignición?", answerType: AnswerType.yn, points: 6),
+        ModuleQuestion(id: "fuentes_ignicion", text: "¿Las tablas de aforo se encuentran en completo orden según la normativa y anexadas al plan de contingencia de la E.D.S.?", answerType: AnswerType.yn, points: 6),
         ModuleQuestion(id: "senalizacion_prohibiciones", text: "¿Existe señalización de prohibición de fumar, apagar motor y otras advertencias necesarias?", answerType: AnswerType.yn, points: 4),
         ModuleQuestion(id: "instalaciones_electricas", text: "¿Las instalaciones eléctricas de las zonas de riesgo presentan condiciones seguras?", answerType: AnswerType.yn, points: 6),
         ModuleQuestion(id: "tableros_electricos", text: "¿Los tableros eléctricos están protegidos, identificados y accesibles?", answerType: AnswerType.yn, points: 3),

--- a/lib/features/inspections/inspection_detail_page.dart
+++ b/lib/features/inspections/inspection_detail_page.dart
@@ -50,17 +50,17 @@ class InspectionDetailPage extends ConsumerWidget {
               tooltip: 'Editar',
               icon: const Icon(Icons.edit),
               onPressed: () async {
-              final result = await Navigator.of(context).push<bool>(
-                MaterialPageRoute(
-                  builder: (_) => NewInspectionWizard(
-                    existing: Map<String, dynamic>.from(inspection),
-                    inspectionId: inspection['id']?.toString(),
+                final result = await Navigator.of(context).push<bool>(
+                  MaterialPageRoute(
+                    builder: (_) => NewInspectionWizard(
+                      existing: Map<String, dynamic>.from(inspection),
+                      inspectionId: inspection['id']?.toString(),
+                    ),
                   ),
-                ),
-              );
-              if (result == true && context.mounted) {
-                Navigator.of(context).pop(true);
-              }
+                );
+                if (result == true && context.mounted) {
+                  Navigator.of(context).pop(true);
+                }
               },
             ),
           IconButton(

--- a/lib/features/inspections/inspection_detail_page.dart
+++ b/lib/features/inspections/inspection_detail_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:printing/printing.dart';
 
 import '../../core/pdf_service.dart';
+import '../../core/providers.dart';
 import '../../core/templates.dart';
 import 'new_inspection_wizard.dart';
 
@@ -36,13 +37,17 @@ class InspectionDetailPage extends ConsumerWidget {
     final modules = (inspection['modules'] ?? []) as List;
 
     final scheme = Theme.of(context).colorScheme;
+    final currentUserId = ref.watch(supabaseProvider).auth.currentUser?.id;
+    final inspectorId = inspection['inspector_id']?.toString();
+    final canEdit = currentUserId != null && inspectorId == currentUserId;
 
     return Scaffold(
       appBar: AppBar(
         title: const Text('Detalle de Inspección'),
         actions: [
-          IconButton(
-            tooltip: 'Editar',
+          if (canEdit)
+            IconButton(
+              tooltip: 'Editar',
             icon: const Icon(Icons.edit),
             onPressed: () async {
               final result = await Navigator.of(context).push<bool>(

--- a/lib/features/inspections/inspection_detail_page.dart
+++ b/lib/features/inspections/inspection_detail_page.dart
@@ -48,8 +48,8 @@ class InspectionDetailPage extends ConsumerWidget {
           if (canEdit)
             IconButton(
               tooltip: 'Editar',
-            icon: const Icon(Icons.edit),
-            onPressed: () async {
+              icon: const Icon(Icons.edit),
+              onPressed: () async {
               final result = await Navigator.of(context).push<bool>(
                 MaterialPageRoute(
                   builder: (_) => NewInspectionWizard(
@@ -61,8 +61,8 @@ class InspectionDetailPage extends ConsumerWidget {
               if (result == true && context.mounted) {
                 Navigator.of(context).pop(true);
               }
-            },
-          ),
+              },
+            ),
           IconButton(
             tooltip: 'PDF',
             icon: const Icon(Icons.picture_as_pdf),

--- a/lib/features/inspections/inspections_list_page.dart
+++ b/lib/features/inspections/inspections_list_page.dart
@@ -15,7 +15,6 @@ final myInspectionsProvider =
   final rows = await supabase
       .from('inspections')
       .select()
-      .eq('inspector_id', user.id)
       .order('created_at', ascending: false);
   return (rows as List).map((e) => Map<String, dynamic>.from(e)).toList();
 });
@@ -49,11 +48,11 @@ class InspectionsListPage extends ConsumerWidget {
     final scheme = Theme.of(context).colorScheme;
 
     return Scaffold(
-      appBar: AppBar(title: const Text('Mis inspecciones')),
+      appBar: AppBar(title: const Text('Inspecciones realizadas')),
       body: asyncList.when(
         data: (rows) {
           if (rows.isEmpty) {
-            return const Center(child: Text('Todavía no hay inspecciones.'));
+            return const Center(child: Text('Todavía no hay inspecciones registradas.'));
           }
           return ListView.separated(
             itemCount: rows.length,

--- a/supabase/migrations/20260820_authenticated_read_all_inspections.sql
+++ b/supabase/migrations/20260820_authenticated_read_all_inspections.sql
@@ -1,0 +1,23 @@
+-- Todos los usuarios autenticados pueden consultar y descargar inspecciones.
+-- Solo el autor conserva permisos de creación y actualización sobre sus registros.
+-- Se eliminan políticas públicas que permitían operaciones sin autenticación.
+
+begin;
+
+alter table public.inspections enable row level security;
+
+drop policy if exists "libre_all" on public.inspections;
+drop policy if exists "Libre para todos - SELECT" on public.inspections;
+drop policy if exists "Libre para todos - INSERT" on public.inspections;
+drop policy if exists "Libre para todos - UPDATE" on public.inspections;
+drop policy if exists "Libre para todos - DELETE" on public.inspections;
+drop policy if exists "authenticated_users_can_view_all_inspections"
+  on public.inspections;
+
+create policy "authenticated_users_can_view_all_inspections"
+on public.inspections
+for select
+to authenticated
+using (true);
+
+commit;


### PR DESCRIPTION
## Cambios
- muestra a todos los usuarios autenticados las inspecciones registradas
- mantiene la edición únicamente para el inspector autor
- conserva la descarga del PDF para otros usuarios
- actualiza la pregunta de tablas de aforo de estación de servicio manteniendo 6 puntos
- documenta la política RLS aplicada en Supabase

## Verificación
- Supabase conserva 110 inspecciones
- se retiraron las políticas públicas de acceso total
- la lectura global exige sesión autenticada
- las políticas de actualización continúan vinculadas a `inspector_id = auth.uid()`